### PR TITLE
Updated css-sprite to version 0.9.6

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -28,6 +28,6 @@
     "opn": "~0.1.2"
   },
   "dependencies": {
-    "css-sprite": "~0.7.0-beta3"
+    "css-sprite": "~0.9.6"
   }
 }


### PR DESCRIPTION
The current version of css-sprite used in this generator throws an error on OSX Yosemite with Node v 0.12.0. Upgrading to 0.9.6 seems to fix this issue.
